### PR TITLE
upload sample video file before running either of the test workflows

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -69,7 +69,7 @@ def stack_resources(testing_env_variables):
 
 
 # This fixture uploads the sample media objects for testing.
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(autouse=True)
 def upload_media(testing_env_variables, stack_resources):
     print('Uploading Test Media')
     s3 = boto3.client('s3', region_name=testing_env_variables['REGION'])


### PR DESCRIPTION
*Issue #, if available:*

#661 

*Description of changes:*

Make the upload fixture run once per test function so the sample video is in the public upload folder, where the workflow config expects it to be.

I think this needs to be merged to development branch before the e2e test will work in github actions. But I've verified it on my laptop. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
