### PR TITLE
fix error with source language autodetect

### DIFF
--- a/source/operators/transcribe/start_transcribe.py
+++ b/source/operators/transcribe/start_transcribe.py
@@ -151,6 +151,7 @@ def lambda_handler(event, context):
     try:
         if identify_language:
             transcribe_job_config['IdentifyLanguage'] = True
+            del transcribe_job_config["LanguageCode"]
         # Run the transcribe job.
         # The ** operator converts the job config dict to keyword arguments.
         response = transcribe.start_transcription_job(**transcribe_job_config)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix this error in start_transcribe for when user enables source language auto detection:

```
Configuration': {'MediaType': 'Audio', 'Enabled': True, 'TranscribeLanguage': 'auto'}, 'Status': 'Error', 'MetaData': {'transcribe_error': "An error occurred (BadRequestException) when calling the StartTranscriptionJob operation: 1 validation error detected: Value 'auto' at 'languageCode' failed to satisfy constraint: Member must satisfy enum value set: [en-IE, ar-AE, te-IN, zh-TW, en-US, ta-IN, en-AB, en-IN, zh-CN, ar-SA, en-ZA, gd-GB, th-TH, tr-TR, ru-RU, pt-PT, nl-NL, it-IT, id-ID, fr-FR, es-ES, de-DE, ga-IE, af-ZA, en-NZ, ko-KR, hi-IN, de-CH, cy-GB, ms-MY, he-IL, da-DK, en-AU, pt-BR, en-WL, fa-IR, ja-JP, es-US, fr-CA, en-GB]"}, 'Media': {}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
