### PR TITLE
Allow webcaptions to use inputs from either transcribe or translate operators

### DIFF
--- a/source/operators/captions/webcaptions.py
+++ b/source/operators/captions/webcaptions.py
@@ -38,7 +38,7 @@ class WebCaptions:
         :param event: The event passed in to the operator
 
         """
-        print("WebCaptions operator_object = {}".format(operator_object))
+        print("WebCaptions operator_object = {}".format(operator_object.return_output_object()))
         self.operator_object = operator_object
 
         try:
@@ -59,6 +59,8 @@ class WebCaptions:
 
             if "TranscribeSourceLanguage" in self.operator_object.input['MetaData']:
                 self.source_language_code = self.operator_object.input['MetaData']['TranscribeSourceLanguage'].split('-')[0]
+            elif "TranslateSourceLanguage" in self.operator_object.input['MetaData']:
+                self.source_language_code = self.operator_object.input['MetaData']['TranslateSourceLanguage'].split('-')[0]
             else:
                 # If TranscribeSourceLanguage is not available, then SourceLanguageCode
                 # must be present in the operator Configuration block.
@@ -505,7 +507,7 @@ class WebCaptions:
                 }
                 translate_jobs.append(jobinfo)
 
-                self.operator_object.add_workflow_metadata(TextTranslateJobPropertiesList=translate_jobs)
+                self.operator_object.add_workflow_metadata(TextTranslateJobPropertiesList=translate_jobs, TranslateSourceLanguage=sourceLanguageCode)
         except Exception as e:
             self.operator_object.update_workflow_status("Error")
             self.operator_object.add_workflow_metadata(TranslateError="Unable to start translation WebCaptions job: {e}".format(e=str(e)))


### PR DESCRIPTION
This fix is needed in order for Save Edits to work for subtitles in the Content Localization application.

Get source language from translate operator if transcribe operator is disabled.

Background:
This is needed by the Content Localization application. When a user clicks Save Edits to update transcripts, the resulting workflow only runs operators downstream from Transcribe. In that case, the Transcribe operator is disabled, and the webcaptions operators will fail to find the source language if they look for it in the input configuration for the transcribe operator.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
