### PR TITLE
workaround Amazon CloudWatch Logs resource policy size restriction

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -15,7 +15,8 @@ docs/assets/images/MIE-architecture-diagram.pptx
 .github/workflows/release-workflow.yml:45
 .github/workflows/release-workflow.yml:46
 .github/workflows/release-workflow.yml:261
-.github/workflows/release-workflow.yml:365
+.github/workflows/release-workflow.yml:349
+.github/workflows/release-workflow.yml:366
 .github/workflows/release-workflow.yml:382
 .github/workflows/scheduled-workflow.yml:19
 .github/workflows/scheduled-workflow.yml:20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - tbd
+
+### Fixed:
+
+* Avoid resource policy size restrictions in AWS Step Functions (#686) 
+
 ## [4.0.0] - 2022-01-11
 
 ### New:

--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -528,6 +528,11 @@ Resources:
             reason: "Log group data is encrypted by default in CloudWatch"        
     Properties:
       RetentionInDays: 14
+      LogGroupName:
+        'Fn::Join':
+          - "-"
+          - - !Sub "/aws/vendedlogs/states/${AWS::StackName}-StepFunctionLogGroup"
+            - !GetAtt GetShortUUID.Data
       Tags:
         - Key: "environment"
           Value: "mie"


### PR DESCRIPTION
*Issue #, if available:*

#685 

*Description of changes:*

Use /aws/vendedlogs/states/ prefix in log group name in order to workaround Amazon CloudWatch Logs resource policy size restriction.

Prior to this PR the StepFunctionLogGroup name looked like this:

<img width="782" alt="image" src="https://user-images.githubusercontent.com/54998167/152061427-1f9a3de4-b327-4233-a7aa-3e6c7de69a4b.png">


This PR will make that name look like this instead:

<img width="781" alt="image" src="https://user-images.githubusercontent.com/54998167/152061380-4e10599e-0600-48cc-bd5e-908b28fb45b9.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
